### PR TITLE
fix: set correct waitlist button width

### DIFF
--- a/src/components/link-button.astro
+++ b/src/components/link-button.astro
@@ -1,30 +1,36 @@
 ---
-type Props = {
+export type Props = {
   href: string;
+  wide?: true;
 };
 
-const { href } = Astro.props;
+const { href, wide = false } = Astro.props;
 ---
 
-<a href={href} class="link-button"><slot /></a>
+<a href={href} class:list={["link-button", { wide }]}><slot /></a>
 
 <style>
-  .link-button {
-    display: block;
+  a {
+    width: fit-content;
     padding: 10px 16px;
     font-size: 14px;
     font-weight: 500;
     text-align: center;
     color: white;
-    background-color: #000000;
     border: none;
     border-radius: 8px;
     cursor: pointer;
     text-decoration: none;
     user-select: none;
+
+    background-color: #000000;
   }
 
-  .link-button:hover {
+  a:hover {
     background-color: #262626;
+  }
+
+  a.wide {
+    width: auto;
   }
 </style>

--- a/src/components/swipeables.astro
+++ b/src/components/swipeables.astro
@@ -106,7 +106,7 @@ const setStyle = (card: (typeof cards)[number]) => {
     </div>
     <div class="actions">
       <a href="/about-us#contact" class="button">Let's talk</a>
-      <WaitlistButton />
+      <WaitlistButton wide />
     </div>
   </div>
 

--- a/src/components/waitlist-button.astro
+++ b/src/components/waitlist-button.astro
@@ -1,5 +1,11 @@
 ---
 import LinkButton from "./link-button.astro";
+
+export type Props = { wide?: true };
+
+const { wide } = Astro.props;
 ---
 
-<LinkButton href="https://tally.so/r/wb6R62">Join waitlist</LinkButton>
+<LinkButton href="https://tally.so/r/wb6R62" wide={wide}>
+  Join waitlist
+</LinkButton>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -82,7 +82,6 @@ const featureCards = z.array(featureCardShape).parse(
         your applications. <span class="smoooothly">Smoooothly.</span>
       </h1>
 
-      <!--TODO: Don't let the button take up the full width-->
       <WaitlistButton />
       <p class="problem">Because: {problem}</p>
     </section>


### PR DESCRIPTION
The waitlist button is supposed to fill the available space at the end of the card game, but only take the space it needs on both the main page and /about-us. This fixes that :smile:

It's deployed to test if you want to take a look: https://sokkel.dev/