### PR TITLE
refactor: use pointermove event instead of both mousemove & touchmove

### DIFF
--- a/src/components/stacky.astro
+++ b/src/components/stacky.astro
@@ -140,8 +140,7 @@ import stacky from '../assets/stacky.svg?raw';
     const eyes = [leftResult.eye, rightResult.eye];
 
     let throttled = false;
-
-    function target({ clientX, clientY }: MouseEvent | Touch) {
+    document.addEventListener('pointermove', (e) => {
       if (throttled) {
         // Ignore any events while throttled.
         return;
@@ -152,17 +151,8 @@ import stacky from '../assets/stacky.svg?raw';
       setTimeout(() => throttled = false, 10);
 
       for (const eye of eyes) {
-        eye.target(new Point(clientX, clientY));
+        eye.target(new Point(e.clientX, e.clientY));
       }
-    }
-
-    document.addEventListener('mousemove', (e) => {
-      target(e);
-    });
-
-    document.addEventListener('touchmove', (e) => {
-      // If there are multiple active touches, take the first one.
-      target(e.touches[0]);
     });
   })();
 </script>


### PR DESCRIPTION
Fixes #19 (h/t @SimenB)